### PR TITLE
Remove CNAME after Cloudflare Pages migration

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-nathang.me


### PR DESCRIPTION
Removes the CNAME file now that the site is hosted on Cloudflare Pages instead of GitHub Pages. The custom domain (nathang.me) is now configured directly in Cloudflare.