### PR TITLE
Add amber terminal easter egg and persistent uptime

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,6 +12,8 @@
 
   Want to chat? me@nathangreenhaw.org
 
+  (Hold Shift while viewing the page)
+
 -->
 <html lang="en">
   <head>
@@ -24,6 +26,12 @@
       :root {
         --terminal-green: #33ff33;
         --terminal-dark: #0a0a0a;
+      }
+      .amber {
+        --terminal-green: #ffb000;
+      }
+      html.transitions-ready, html.transitions-ready *, html.transitions-ready *::before, html.transitions-ready *::after {
+        transition: color 100ms, text-shadow 100ms, border-color 100ms, box-shadow 100ms;
       }
 
       * {
@@ -229,6 +237,17 @@
       // Keep focus on input (works for both click and touch)
       document.addEventListener('click', () => input.focus());
       terminal.addEventListener('touchstart', () => input.focus());
+
+      // Amber easter egg
+      requestAnimationFrame(() => {
+        document.documentElement.classList.add('transitions-ready');
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Shift') document.documentElement.classList.add('amber');
+      });
+      document.addEventListener('keyup', (e) => {
+        if (e.key === 'Shift') document.documentElement.classList.remove('amber');
+      });
     </script>
   </body>
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -7,6 +7,19 @@
   --accent-color: var(--terminal-green);
 }
 
+/* Amber terminal easter egg */
+html.transitions-ready {
+  transition: color 100ms, text-shadow 100ms;
+}
+html.transitions-ready *, html.transitions-ready *::before, html.transitions-ready *::after {
+  transition: color 100ms, text-shadow 100ms, border-color 100ms, box-shadow 100ms;
+}
+.amber {
+  --terminal-green: #ffb000;
+  --terminal-dim: #5c4a1a;
+  --border-color-faint: rgba(92, 74, 26, 0.4);
+}
+
 * {
   box-sizing: border-box;
 }

--- a/css/resume.css
+++ b/css/resume.css
@@ -4,6 +4,15 @@
   --terminal-dim: #1a5c1a;
 }
 
+/* Amber terminal easter egg */
+.amber {
+  --terminal-green: #ffb000;
+  --terminal-dim: #5c4a1a;
+}
+html.transitions-ready, html.transitions-ready *, html.transitions-ready *::before, html.transitions-ready *::after {
+  transition: color 100ms, text-shadow 100ms, border-color 100ms, box-shadow 100ms;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
   Want to chat? me@nathangreenhaw.org
 
+  (Hold Shift while viewing the page)
+
 -->
 <html lang="en">
 <head>
@@ -193,14 +195,33 @@
   setTimeout(runScramble2, 500);
   setInterval(runScramble2, 25000);
 
-  // Uptime counter
-  const startTime = Date.now();
+  // Uptime counter (persists across visits)
+  const UPTIME_KEY = 'nathang_first_visit';
+  let startTime = localStorage.getItem(UPTIME_KEY);
+  if (!startTime) {
+    startTime = Date.now();
+    localStorage.setItem(UPTIME_KEY, startTime);
+  }
+  startTime = parseInt(startTime, 10);
   const uptimeEl = document.getElementById('uptime');
+
+  function formatUptime(seconds) {
+    const years = Math.floor(seconds / 31536000);
+    const days = Math.floor((seconds % 31536000) / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    let result = `${mins}m ${secs}s`;
+    if (hours > 0 || days > 0 || years > 0) result = `${hours}h ${result}`;
+    if (days > 0 || years > 0) result = `${days}d ${result}`;
+    if (years > 0) result = `${years}y ${result}`;
+    return result;
+  }
+
   function updateUptime() {
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
-    const mins = Math.floor(elapsed / 60);
-    const secs = elapsed % 60;
-    uptimeEl.textContent = `uptime: ${mins}m ${secs}s`;
+    uptimeEl.textContent = `uptime: ${formatUptime(elapsed)}`;
   }
   updateUptime();
   setInterval(updateUptime, 1000);
@@ -248,6 +269,18 @@
   }
 
   type();
+</script>
+
+<script>
+  requestAnimationFrame(() => {
+    document.documentElement.classList.add('transitions-ready');
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Shift') document.documentElement.classList.add('amber');
+  });
+  document.addEventListener('keyup', (e) => {
+    if (e.key === 'Shift') document.documentElement.classList.remove('amber');
+  });
 </script>
 </body>
 </html>

--- a/resume.html
+++ b/resume.html
@@ -155,5 +155,16 @@
         </article>
       </div>
     </div>
+    <script>
+      requestAnimationFrame(() => {
+        document.documentElement.classList.add('transitions-ready');
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Shift') document.documentElement.classList.add('amber');
+      });
+      document.addEventListener('keyup', (e) => {
+        if (e.key === 'Shift') document.documentElement.classList.remove('amber');
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Hold Shift on any page to temporarily switch from green to amber terminal colors, a nod to vintage amber phosphor monitors. Also makes the uptime counter persist across visits using localStorage, with adaptive formatting as time accumulates (e.g., "5m 30s" → "1h 5m 30s" → "1d 0h 5m 30s").